### PR TITLE
Dev/fix gcc8 issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pci_mav)
 
-add_definitions(-std=c++11)
+add_definitions(-std=c++11 -Wall -Wno-sign-compare -Werror=return-type)
 
 find_package(catkin_simple REQUIRED)
 find_package(Eigen3 REQUIRED)

--- a/src/pci_mav.cpp
+++ b/src/pci_mav.cpp
@@ -242,7 +242,9 @@ PCIMAV::generateTrajectoryMarkerArray(
     mo.pose.orientation.w = ti_q.w;
     m_arr->markers.push_back(mo);
   }
-  if(!m_arr->markers.empty()) ++mo.id;
+  if(!m_arr->markers.empty()) {
+    ++mo.id;
+  }
   auto tb_v3 = traj.points.back().transforms.at(0).translation;
   mo.pose.position.x = tb_v3.x;
   mo.pose.position.y = tb_v3.y;

--- a/src/pci_mav.cpp
+++ b/src/pci_mav.cpp
@@ -417,6 +417,7 @@ bool PCIMAV::executePath(const std::vector<geometry_msgs::Pose> &path,
     ROS_ERROR("PCIMAV::executePath --> Not support.");
   }
   ROS_WARN("PCI: Ready to trigger the planner.");
+  return true;
 }
 
 void PCIMAV::interpolatePath(const std::vector<geometry_msgs::Pose> &path,

--- a/src/pci_mav.cpp
+++ b/src/pci_mav.cpp
@@ -306,7 +306,7 @@ bool PCIMAV::executePath(const std::vector<geometry_msgs::Pose> &path,
 
   // Execute the path.
   if (run_mode_ == RunModeType::kSim) {
-    // In simulation, have to interpolate the path to make it works smoother,
+    // In simulation, the path needs to be interpolated for smoother behavior,
     // since it is using lee-controller.
     n_seq_++;
     std::vector<geometry_msgs::Pose> path_intp;
@@ -343,7 +343,7 @@ bool PCIMAV::executePath(const std::vector<geometry_msgs::Pose> &path,
       ros::Duration(delta_wait).sleep();
       ros::spinOnce();
     }
-    // If stop before the wait-time, trigger as an error.
+    // If stopped before end of the wait-time, trigger as an error.
     // Need this to reset everything to default mode.
     if (force_stop_) {
       force_stop_ = false;

--- a/src/pci_mav.cpp
+++ b/src/pci_mav.cpp
@@ -216,7 +216,10 @@ PCIMAV::generateTrajectoryMarkerArray(
   mo.frame_locked = false;
 
   for (size_t i = 0; i < traj.points.size() - 1; ++i) {
-    m_arr->markers.empty() ?: ++me.id, ++mo.id;
+    if(!m_arr->markers.empty()) {
+      ++me.id;
+      ++mo.id;
+    }
     auto ti_v3 = traj.points.at(i).transforms.at(0).translation;
     auto tip1_v3 = traj.points.at(i + 1).transforms.at(0).translation;
     auto &me_p0 = me.points.at(0);
@@ -239,7 +242,7 @@ PCIMAV::generateTrajectoryMarkerArray(
     mo.pose.orientation.w = ti_q.w;
     m_arr->markers.push_back(mo);
   }
-  m_arr->markers.empty() ?: ++mo.id;
+  if(!m_arr->markers.empty()) ++mo.id;
   auto tb_v3 = traj.points.back().transforms.at(0).translation;
   mo.pose.position.x = tb_v3.x;
   mo.pose.position.y = tb_v3.y;
@@ -791,6 +794,8 @@ double PCIMAV::getVelocity(ExecutionPathType path_type) {
     return v_homing_max_;
   } else if (path_type == ExecutionPathType::kNarrowEnvPath) {
     return v_narrow_env_max_;
+  } else {
+    return v_max_;  // By default return maximum velocity for local path execution
   }
 }
 


### PR DESCRIPTION
This PR solves the issue of pci_mav crashing when compiled with gcc/++ 8. 
Corresponding issue: ntnu-arl/gbplanner_ros#7. 